### PR TITLE
[hebe-jvm] Migrate BouncyCastle to x509-generator.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        jcenter()
     }
 }
 

--- a/hebe-jvm/build.gradle
+++ b/hebe-jvm/build.gradle
@@ -4,6 +4,5 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.66'
-    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.66'
+    implementation 'eu.szkolny:x509-generator:1.0.0'
 }


### PR DESCRIPTION
This PR removes the usage of the very heavy-weighted BouncyCastle in favor of szkolny-eu/x509-generator, making the library suitable for both JVM and Android usage.